### PR TITLE
🔒️ Fix commons-io CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,9 +42,9 @@ dependencies {
     implementation "org.slf4j:slf4j-api:${slf4j_version}"
     implementation "com.github.adedayo.intellij.sdk:annotations-java8:${intellij_annotations_version}"
     implementation "commons-codec:commons-codec:${commons_codec_version}"
-    implementation "commons-io:commons-io:${commons_version}"
+    implementation "commons-io:commons-io:${commons_io_version}"
     implementation "com.google.guava:guava:${guava_version}"
-    implementation "commons-lang:commons-lang:${commons_version}"
+    implementation "commons-lang:commons-lang:${commons_lang_version}"
     implementation "com.vdurmont:semver4j:${semver4j_version}"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,8 @@ slf4j_version=1.7.33
 semver4j_version=3.1.0
 intellij_annotations_version=142.1
 commons_codec_version=1.15
-commons_version=2.6
+commons_lang_version=2.6
+commons_io_version=2.7
 guava_version=31.0.1-jre
 
 # tests


### PR DESCRIPTION
- Split commons version : commons-lang and commons-io shared the same version (2.6)
- Update commons-io to 2.7 as the 2.6 one contains a CVE

cf https://mvnrepository.com/artifact/com.github.differentway/couchmove/3.3